### PR TITLE
Fix playlist unchanged to check endList

### DIFF
--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -92,11 +92,12 @@ export const updateMaster = (master, media) => {
     return null;
   }
 
-  // consider the playlist unchanged if the number of segments is equal and the media
-  // sequence number is unchanged
+  // consider the playlist unchanged if the number of segments is equal, the media
+  // sequence number is unchanged, and this playlist hasn't become the end of the playlist
   if (playlist.segments &&
       media.segments &&
       playlist.segments.length === media.segments.length &&
+      playlist.endList === media.endList &&
       playlist.mediaSequence === media.mediaSequence) {
     return null;
   }

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -190,6 +190,51 @@ QUnit.test('updateMaster updates master when new media sequence', function(asser
     'updates master when new media sequence');
 });
 
+QUnit.test('updateMaster updates master when endList changes', function(assert) {
+  const playlist = {
+    endList: false,
+    mediaSequence: 0,
+    attributes: {
+      BANDWIDTH: 9
+    },
+    uri: 'playlist-0-uri',
+    resolvedUri: urlTo('playlist-0-uri'),
+    segments: [{
+      duration: 10,
+      uri: 'segment-0-uri',
+      resolvedUri: urlTo('segment-0-uri')
+    }]
+  };
+
+  const master = {
+    playlists: [playlist]
+  };
+
+  const media = Object.assign({}, playlist, {
+    endList: true
+  });
+
+  assert.deepEqual(
+    updateMaster(master, media),
+    {
+      playlists: [{
+        endList: true,
+        mediaSequence: 0,
+        attributes: {
+          BANDWIDTH: 9
+        },
+        uri: 'playlist-0-uri',
+        resolvedUri: urlTo('playlist-0-uri'),
+        segments: [{
+          duration: 10,
+          uri: 'segment-0-uri',
+          resolvedUri: urlTo('segment-0-uri')
+        }]
+      }]
+    },
+    'updates master when endList changes');
+});
+
 QUnit.test('updateMaster retains top level values in master', function(assert) {
   const master = {
     mediaGroups: {


### PR DESCRIPTION
Add a check for `endList` when determining if the playlist is unchanged or not.